### PR TITLE
Record Preview 3 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ have been exercised on iPad. The customizable phone layout, A hold assist,
 safe-area menu placement, texture-pack rendering, and Grand Prix play have
 also been exercised on iPhone.
 
-Those results do not certify every configuration. The published preview
-artifact has been audited and its exact payload has been installed and
-launched on a physical iPad; the latest development build has also been
-installed, launched, and touch-tested on a physical iPhone.
+Those results do not certify every configuration. The published Preview 3
+artifact has been audited; its exact payload has been temporarily re-signed,
+update-installed, launched, and verified live on a physical iPhone. Signed
+development builds have also been installed, launched, and touch-tested on a
+physical iPad.
 Bluetooth-controller mapping and reconnect behavior, sustained multiplayer
 performance, a complete touch-only Grand Prix, and a complete tilt-driven
 Grand Prix remain explicit validation gates.
@@ -298,7 +299,7 @@ M-series-iPad performance experiment until it has its own hardware evidence.
 | Saves and updates | Development update installs have retained the current app container; the final audited update/save-preservation gate remains |
 | Controllers | Four-port routing and split-screen rendering pass deterministic Simulator tests; physical model, reconnect, and multiplayer sessions remain |
 | Tilt | The persisted motion-to-stick path, recentering, touch priority, and foreground recalibration pass Simulator tests; physical feel and a tilt GP remain |
-| Packaging | Preview 3 packages the promoted customizable touch controls in an audited, ROM-free unsigned IPA |
+| Packaging | Preview 3 packages the promoted customizable controls in an audited, ROM-free unsigned IPA; its exact payload has been re-signed and launched on a physical iPhone |
 | CI | Repository safety and the ROM-free unsigned iPhoneOS build/package workflow pass on hosted GitHub Actions |
 
 The project deliberately keeps build, Simulator, process, and physical-device

--- a/docs/INSTALL_IPA.md
+++ b/docs/INSTALL_IPA.md
@@ -72,7 +72,8 @@ physical-device update gate passes.
   phone and tablet layouts, control move/resize/hide/reset tools, and A-button
   hold assist.
 - Customizable controls and gameplay have been exercised on physical iPhone
-  and iPad development builds. Exact-payload installation is recorded
-  separately in the release notes.
+  and iPad development builds. The exact published Preview 3 payload was
+  temporarily re-signed, update-installed, launched, and verified live on a
+  physical iPhone without changing the public IPA.
 - Long-session stability, controller behavior, performance, and final in-place
   update/save preservation remain explicit acceptance gates.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -73,8 +73,10 @@ This is the final gate for a public source snapshot or downloadable IPA.
   remaining physical-hardware gates are still open.
 - Preview 3 promotes the customizable touch controls to the default, retains
   legacy controls as an option, and carries separate physically tuned phone
-  and tablet layouts. Its exact artifact evidence is recorded in the GitHub
-  release notes.
+  and tablet layouts. Its exact artifact was temporarily re-signed,
+  update-installed, launched, and verified live on a physical iPhone, then
+  published with its checksum as
+  [`v0.1.0-preview.3`](https://github.com/chrissotraidis/spaghettipad/releases/tag/v0.1.0-preview.3).
 
 These blockers may be stated as developer-preview limitations, but they must
 not be described as passed.

--- a/docs/remaining-work.md
+++ b/docs/remaining-work.md
@@ -53,7 +53,7 @@ audited ROM-free unsigned IPA.
 | 9 | iPad UX and imported texture pack | In progress (Simulator UX/import slice passed; hardware pack GP pending) | Touch-complete UX plus Reloaded import/enable/full-GP hardware gate |
 | 10 | Controllers and split-screen | In progress (Simulator routing/render slice passed; hardware sessions pending) | Two-controller 2P session and measured 3P/4P decision |
 | 11 | Tilt steering | In progress (Simulator slice passed; hardware GP pending) | Persisted, drift-free tilt GP on hardware |
-| 12 | Package, CI, docs, release | In progress (Preview 2 published; clean hosted CI and package workflow passed) | Final physical update/save-preservation acceptance |
+| 12 | Package, CI, docs, release | In progress (Preview 3 published; exact IPA passed audit and physical-iPhone launch) | Final physical update/save-preservation acceptance |
 
 ## Active gate
 
@@ -170,6 +170,39 @@ Boundary:
   [30406005730](https://github.com/chrissotraidis/spaghettipad/actions/runs/30406005730)
   remains an external pre-start failure with zero steps and the unchanged
   GitHub billing/spending-limit annotation.
+
+### 2026-07-29 — Preview 3 customizable-controls release published
+
+- Release: annotated tag
+  [`v0.1.0-preview.3`](https://github.com/chrissotraidis/spaghettipad/releases/tag/v0.1.0-preview.3)
+  resolves to merged `main` commit
+  `5786e6faa74487a8be7bdfe30d8b2bb2a7a54541`.
+- Controls: Preview 3 is the first downloadable IPA with customizable touch
+  controls as the default, separate phone/tablet profiles, move, resize, hide,
+  show, and reset tools, A-button hold assist, and an optional legacy mode.
+- Clean build: hosted repository safety and unsigned arm64 iPhoneOS
+  build/package jobs passed in
+  [run 30481595201](https://github.com/chrissotraidis/spaghettipad/actions/runs/30481595201).
+  The artifact is version `0.1.0`, build `3`, minimum iOS/iPadOS 15.0, built
+  with Xcode 16.4 and the iPhoneOS 18.5 SDK.
+- IPA audit: `SpaghettiPad-0.1.0-preview.3-unsigned.ipa` is 11,228,922 bytes
+  with 293 ZIP entries and SHA-256
+  `4b74433290c1dba54f5b4a31820c835fd826359ebd172fe0351c4115182c388b`.
+  It is unsigned and contains no ROM, extracted game archive, imported texture
+  pack, provisioning profile, certificate, or signing identity. The only
+  `.o2r` is the pinned, ROM-free `spaghetti.o2r`.
+- Exact-artifact device check: a temporary extracted copy of the exact IPA was
+  signed with the established development profile, passed strict signature
+  verification and the signed-app audit, update-installed without uninstalling,
+  launched, and observed as a live process on a physical iPhone 14 running iOS
+  26.5.2. The public IPA remained unchanged and unsigned.
+- Live publication check: both release assets were downloaded back from
+  GitHub; `SHA256SUMS` passed and the downloaded IPA's compressed-data audit
+  reported no errors.
+- Boundary: this evidence proves build, package integrity, install, launch,
+  and live process state. The extended gameplay, controller, tilt,
+  performance, long-session, and final cross-release update/save-preservation
+  gates remain open.
 
 ### 2026-07-29 — Preview 2 release hardening completed
 


### PR DESCRIPTION
## Summary
- record the exact Preview 3 artifact checksum, size, build environment, and tag commit
- record the exact-payload physical iPhone install, launch, and live-process evidence
- update current public docs so Preview 3, rather than Preview 2, is described as the latest package

## Validation
- live release assets downloaded back from GitHub
- SHA256SUMS verification passed
- IPA compressed-data audit passed
- clean-checkout repository safety audit passed

This PR changes documentation only.